### PR TITLE
Update README.md to avoid permission denied error

### DIFF
--- a/extra/ubuntu/README.md
+++ b/extra/ubuntu/README.md
@@ -32,7 +32,7 @@ sudo cmake --install . --prefix /usr
 cd ginga _build
 cmake .. -G Ninja  -DCMAKE_BUILD_TYPE=Release
 ninja 
-cpack
+sudo cpack
 ```
 
 To deploy installer on github, run:

--- a/extra/ubuntu/README.md
+++ b/extra/ubuntu/README.md
@@ -23,7 +23,7 @@ cd ginga
 mkdir _build && cd _build
 cmake .. -G Ninja 
 ninja
-cmake --install . --prefix /usr
+sudo cmake --install . --prefix /usr
 ```
 
 ### Build installer


### PR DESCRIPTION
Simple thing. Avoid the following error by using `sudo` when following the readme

![image](https://github.com/TeleMidia/ginga/assets/27526023/bc9217c5-786e-42fc-a780-bda370d70b41)
