### PR TITLE
ci: fixed doxygen gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,28 +7,38 @@ on:
       - "lib/*"
       - "doc/*"
       - "src/*"
+      - ".github/workflows/gh-pages.yml"
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   gh-pages:
     runs-on: ubuntu-latest
+    container:
+      image: rodrigodornelles/doxygen:lua
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y cmake make doxygen graphviz
+      - run: sudo apt-get -y update
+      - run: sudo apt-get -y install cmake g++
       - name: cmake
         working-directory: ./doc
         run: cmake .
       - name: build docs
         working-directory: ./doc
         run: cmake --build .
-      - name: Deploy to GitHub Pages
-        if: success()
-        uses: crazy-max/ghaction-github-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          target_branch: gh-pages
-          build_dir: ./doc/html
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: 'doc/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,8 +25,8 @@ jobs:
       image: rodrigodornelles/doxygen:lua
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get -y update
-      - run: sudo apt-get -y install cmake g++
+      - run: apt-get -y update
+      - run: apt-get -y install cmake g++
       - name: cmake
         working-directory: ./doc
         run: cmake .


### PR DESCRIPTION
I made some configurations in the workflow to get the documentation working again.

preview <https://rodrigodornelles.github.io/fork-ginga/>
solves #191

- I used my own docker image, as it is always updated with the latest version of plantuml, graphviz and doxygen. <br/><https://hub.docker.com/r/rodrigodornelles/doxygen>
- I put the official gh-actions deployment plugin to use, which is currently working well.
- I made some adjustments to the repository permissions.

If you have any questions, just contact me and I can make a call to help you configure the repository.

 * **email:** <rodrigo.dornelles@zedia.com.br>
 * **discord:** DornellesTV

---
@rafael2k @alanlivio 
